### PR TITLE
fix(example): cast page status code into integer

### DIFF
--- a/examples/api-static/services/api.js
+++ b/examples/api-static/services/api.js
@@ -188,7 +188,7 @@ const routes = {
       order: 0
     });
 
-    page.statusCode = ctx.params.statusCode;
+    page.statusCode = +ctx.params.statusCode;
 
     return page;
   },


### PR DESCRIPTION
fix https://github.com/ekino/rendr/issues/33