### PR TITLE
feat(aggregator): add Page arg to Handler type

### DIFF
--- a/examples/nextjs/pages/_rendr.ts
+++ b/examples/nextjs/pages/_rendr.ts
@@ -31,7 +31,7 @@ const templates = {
 // ie: handlers aggregate values and set them into a block.
 //  => Aggregation at the view level is not that good but can be useful in some cases.
 const handlers = {
-  "rendr.agencies": (block: BlockDefinition, ctx: RequestCtx) =>
+  "rendr.agencies": (block: BlockDefinition, ctx: RequestCtx, page: Page) =>
     Promise.resolve(block)
 };
 

--- a/packages/aggregator/src/index.ts
+++ b/packages/aggregator/src/index.ts
@@ -11,7 +11,7 @@ export function createAggregatorLoader(handlers: HandlerList): Loader {
       page.blocks.map(async block => {
         const handler = handlerRegistry(block.type);
 
-        const result = await handler(block, ctx);
+        const result = await handler(block, ctx, page);
 
         return result;
       })

--- a/packages/aggregator/src/types.ts
+++ b/packages/aggregator/src/types.ts
@@ -6,7 +6,8 @@ export type HandlerList = {
 
 export type Handler = (
   definition: BlockDefinition,
-  ctx: RequestCtx
+  ctx: RequestCtx,
+  page: Page
 ) => Promise<BlockDefinition>;
 
 export type HandlerRegistry = (code: string) => Handler;


### PR DESCRIPTION
This PR adds a `Page` parameter to the `Handler` type. 

This exposes Page data when aggregating blocks. The function signature of a `Handler` now includes both page and request context, aligning closer with the signature of a `Loader`. 

It's possible that a developer would need to amend block settings in response to page data. This was previously not possible and the developer would have to infer information based on the request context. 

