### PR TITLE
feat(loader): forward user agent header to Rendr api endpoint

### DIFF
--- a/packages/loader/src/services/api.ts
+++ b/packages/loader/src/services/api.ts
@@ -31,6 +31,9 @@ export function createApiLoader(baseUrl: string): Loader {
       if ("range" in ctx.req.headers) {
         headers["range"] = ctx.req.headers["range"];
       }
+      if ("user-agent" in ctx.req.headers) {
+        headers["user-agent"] = ctx.req.headers["user-agent"];
+      }
 
       headers["accept"] = ctx.req.headers["accept"];
       // please note: axios does not support br (brotli)


### PR DESCRIPTION
This PR affects the `core/loader` package. It specifically modifies the `createApiLoader` function.

The change adds `user-agent` to the selection of request headers that are forwarded to the Rendr API endpoint. 

## Benefits
Forwarding the user agent string means we can optionally parse it on the aggregation layer and add data about the user's browser to the response. Most significantly, this can be used to add a `className` attribute to the `page.head.htmlAttributes` object. 

## Downsides
I don't see any downsides. Currently, the user-agent is always "axios/0.19.2", which serves no purpose that I can think of.